### PR TITLE
Fix SCM validation for url in git@hostname format

### DIFF
--- a/ui/app/common/directives/pncScmValidator.js
+++ b/ui/app/common/directives/pncScmValidator.js
@@ -45,7 +45,7 @@
   module.directive('pncScmValidator', function () {
 
       var isScmUrl = function(allowedProtocols, exactHost, url) {
-        allowedProtocols = allowedProtocols.replace('git@', 'git@[\\w\\.]+').replace('git+ssh', 'git\\+ssh');
+        allowedProtocols = allowedProtocols.replace('git@', 'git@[\\w\\.\\-]+').replace('git+ssh', 'git\\+ssh');
         exactHost = exactHost && exactHost.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&');
 
         var pattern = new RegExp(


### PR DESCRIPTION
...for hostnames containing a hyphen.