### PR TITLE
[NCLSUP-1101] Highlight the build script error on entering the edit build config page

### DIFF
--- a/ui/app/build-configs/directives/pnc-create-build-config-general-form/pnc-create-build-config-general-form.html
+++ b/ui/app/build-configs/directives/pnc-create-build-config-general-form/pnc-create-build-config-general-form.html
@@ -44,7 +44,7 @@
     <p ng-show="form.buildType.$invalid && form.buildType.$touched" class="help-block">Build Type is a required field.</p>
   </div>
 
-  <div class="form-group" ng-class="{ 'has-error' : form.buildScript.$invalid && form.buildScript.$touched, 'has-success': form.buildScript.$valid && form.buildScript.$touched }">
+  <div class="form-group" ng-class="{ 'has-error' : form.buildScript.$invalid && form.buildScript.$touched || form.buildScript.$error.forbiddenBuildScript, 'has-success': form.buildScript.$valid && form.buildScript.$touched }">
     <label ng-if="$ctrl.isMavenValidationActive()" class="control-label required" for="build-config-build-script">Build Script</label>
     <label ng-if="!$ctrl.isMavenValidationActive()" class="control-label required" for="build-config-build-script2">Build Script</label>
     <textarea ng-if="$ctrl.isMavenValidationActive()" id="build-config-build-script" name="buildScript" class="form-control" spellcheck=false ng-model="$ctrl.data.buildScript" spellcheck="false" pnc-build-script-validator pnc-build-script-forbidden-validator required></textarea>


### PR DESCRIPTION
To test this jira: manually create a maven build config with a script containing -X; you can use curl or REST API. Then enter the edit page of this build config and verify the field turns red on entering the edit page.